### PR TITLE
Allow failure for macos gcc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             CPPFLAGS: "-I$(brew --prefix)/opt/fftw/include"
             CC: gcc-13
             CXX: g++-13
+            continue-on-error: true
           - os: macos-latest
             compiler: clang
             INSTALL_DEPS: brew install fftw libomp
@@ -50,9 +51,6 @@ jobs:
             CPPFLAGS: "-I$(brew --prefix)/opt/fftw/include -I$(brew --prefix)/opt/libomp/include"
             CC: clang
             CXX: clang++
-
-    continue-on-error: >-
-      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && success() || failure() }}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && true || false }}
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' || false }}
       
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
             CC: clang
             CXX: clang++
 
+    continue-on-error: >-
+      ${{ matrix.os == "macos-latest" && matrix.compiler == "gcc" && true || false }}
+
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ contains(matrix.os,'macos') && contains(matrix.compiler,'gcc') && true || false }}
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && true || false }}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "~3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "~3.13.0-0"]
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, clang]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && true || false }}
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && success() || failure() }}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ matrix.os == "macos-latest" && matrix.compiler == "gcc" && true || false }}
+      ${{ contains(matrix.os,"macos") && contains(matrix.compiler,"gcc") && true || false }}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' || false }}
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' }}
       
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "~3.13"]
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, clang]
         exclude:
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' }}
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' || contains(matrix.python-version, '~') }}
       
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CXX: clang++
 
     continue-on-error: >-
-      ${{ contains(matrix.os,"macos") && contains(matrix.compiler,"gcc") && true || false }}
+      ${{ contains(matrix.os,'macos') && contains(matrix.compiler,'gcc') && true || false }}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
             CPPFLAGS: "-I$(brew --prefix)/opt/fftw/include"
             CC: gcc-13
             CXX: g++-13
-            continue-on-error: true
           - os: macos-latest
             compiler: clang
             INSTALL_DEPS: brew install fftw libomp
@@ -52,6 +51,9 @@ jobs:
             CC: clang
             CXX: clang++
 
+    continue-on-error: >-
+      ${{ matrix.os == 'macos-latest' && matrix.compiler == 'gcc' && true || false }}
+      
     steps:
       - name: Checkout project
         uses: actions/checkout@v4


### PR DESCRIPTION
This patch is intended to allow building on `macos-latest`, using `gcc` compiler, to fail without failing the final CI check.